### PR TITLE
backend55

### DIFF
--- a/src/main/java/org/soulcodeacademy/helpr/services/ChamadoService.java
+++ b/src/main/java/org/soulcodeacademy/helpr/services/ChamadoService.java
@@ -72,6 +72,11 @@ public class ChamadoService {
                     chamadoAtual.setFuncionario(funcionario);
                     chamadoAtual.setDataFechamento(LocalDate.now());
                 }
+                case ARQUIVADO -> {
+                    chamadoAtual.setStatus(StatusChamado.ARQUIVADO);
+                    chamadoAtual.setFuncionario(null);
+                    chamadoAtual.setDataFechamento(null);
+                }
             }
         }
 
@@ -96,3 +101,7 @@ public class ChamadoService {
         return this.chamadoRepository.buscarEntreDatas(data1, data2);
     }
 }
+
+
+
+


### PR DESCRIPTION
|BACK-END| Novo status de ARQUIVADO em Chamados #55

[ ] - Adicionar ao enum de StatusChamado a constante ARQUIVADO. Esse status indica que o chamado está num estado de "Apagado do sistema", porém ele não será apagado de verdade.

[ } - Em seguida, verifique como o método de atualizar chamado irá se comportar com a adição desta nova opção, faça as alterações necessárias (ao arquivar um chamado não altera os dados já presentes no chamado).